### PR TITLE
Fixed runtests.py errors

### DIFF
--- a/{{cookiecutter.repo_name}}/runtests.py
+++ b/{{cookiecutter.repo_name}}/runtests.py
@@ -2,30 +2,28 @@ import sys
 
 try:
     from django.conf import settings
+
+    settings.configure(
+        DEBUG=True,
+        USE_TZ=True,
+        DATABASES={
+            "default": {
+                "ENGINE": "django.db.backends.sqlite3",
+            }
+        },
+        ROOT_URLCONF="{{ cookiecutter.app_name }}.urls",
+        INSTALLED_APPS=[
+            "django.contrib.auth",
+            "django.contrib.contenttypes",
+            "django.contrib.sites",
+            "{{ cookiecutter.app_name }}",
+        ],
+        SITE_ID=1,
+    )
+
     from django_nose import NoseTestSuiteRunner
 except ImportError:
-    raise ImportError("To fix this error, run: pip install -r requirement-text.txt")
-
-settings.configure(
-    DEBUG=True,
-    USE_TZ=True,
-    DATABASES={
-        "default": {
-            "ENGINE": "django.db.backends.sqlite3",
-        }
-    },
-    ROOT_URLCONF="{{ cookiecutter.app_name }}.urls",
-    INSTALLED_APPS=[
-        "django.contrib.auth",
-        "django.contrib.contenttypes",
-        "django.contrib.sites",
-        "{{ cookiecutter.app_name }}",
-    ],
-    SITE_ID=1,
-    # Custom project settings go here
-
-
-)
+    raise ImportError("To fix this error, run: pip install -r requirements-test.txt")
 
 test_runner = NoseTestSuiteRunner(verbosity=1)
 failures = test_runner.run_tests(["."])


### PR DESCRIPTION
Fixed two errors:
- `pip install -r requirement-text.txt` should be `pip install -r requirements-test.txt`
- better to import `from django_nose import NoseTestSuiteRunner` after `settings.configure` otherwise it might give configuration errors
