### PR TITLE
Improved nose configuration

### DIFF
--- a/{{cookiecutter.repo_name}}/runtests.py
+++ b/{{cookiecutter.repo_name}}/runtests.py
@@ -1,4 +1,5 @@
 import sys
+from optparse import OptionParser
 
 try:
     from django.conf import settings
@@ -19,14 +20,28 @@ try:
             "{{ cookiecutter.app_name }}",
         ],
         SITE_ID=1,
+        NOSE_ARGS=['-s'],
     )
 
     from django_nose import NoseTestSuiteRunner
 except ImportError:
     raise ImportError("To fix this error, run: pip install -r requirements-test.txt")
 
-test_runner = NoseTestSuiteRunner(verbosity=1)
-failures = test_runner.run_tests(["."])
 
-if failures:
-    sys.exit(failures)
+def run_tests(*test_args):
+    if not test_args:
+        test_args = ['tests']
+
+    # Run tests
+    test_runner = NoseTestSuiteRunner(verbosity=1)
+
+    failures = test_runner.run_tests(test_args)
+
+    if failures:
+        sys.exit(failures)
+
+
+if __name__ == '__main__':
+    parser = OptionParser()
+    (options, args) = parser.parse_args()
+    run_tests(*args)


### PR DESCRIPTION
Adds nose arg `-s` and allows the developer to specify what tests have to be run when calling `run tests.py` 
