### PR TITLE
Fixed package name in setup.py

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -4,14 +4,14 @@
 import os
 import sys
 
-import {{ cookiecutter.repo_name }}
+import {{ cookiecutter.app_name }}
 
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
 
-version = {{ cookiecutter.repo_name }}.__version__
+version = {{ cookiecutter.app_name }}.__version__
 
 if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')
@@ -32,7 +32,7 @@ setup(
     author_email='{{ cookiecutter.email }}',
     url='https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}',
     packages=[
-        '{{ cookiecutter.repo_name }}',
+        '{{ cookiecutter.app_name }}',
     ],
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
I changed `cookiecutter.repo_name` to `cookiecutter.app_name` which is the python package name
