### PR TITLE
Solves issue #11

### DIFF
--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -4,6 +4,6 @@ envlist = py26, py27, py33
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/{{ cookiecutter.app_name }}
-commands = python setup.py test
+commands = python runtests.py
 deps =
-    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/requirements-test.txt


### PR DESCRIPTION
This is a pull request for issue #11 
Changes tox.ini to run tests from runtests.py and use requirements-test.txt
