### PR TITLE
Remove use of optparse, simply use sys.argv for runtests.py

### DIFF
--- a/{{cookiecutter.repo_name}}/runtests.py
+++ b/{{cookiecutter.repo_name}}/runtests.py
@@ -1,5 +1,4 @@
 import sys
-from optparse import OptionParser
 
 try:
     from django.conf import settings
@@ -42,6 +41,4 @@ def run_tests(*test_args):
 
 
 if __name__ == '__main__':
-    parser = OptionParser()
-    (options, args) = parser.parse_args()
-    run_tests(*args)
+    run_tests(*sys.argv[1:])


### PR DESCRIPTION
OptionParser seems better designed for when we want explicit set of command
line arguments to pass. In this case, we simply want to pass through
any command line args straight to nose runner, allowing it to
handle them as necessary.

Prior to this, it'd be impossible to pass nose args via the command line.
