### PR TITLE
Move shebang line to top

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -1,5 +1,5 @@
-# -*- coding: utf-8 -*-
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import os
 import sys


### PR DESCRIPTION
The [shebang line](https://en.wikipedia.org/wiki/Shebang_%28Unix%29) should come first, followed by encoding declaration ([pep-0263](http://www.python.org/dev/peps/pep-0263/)).
