### PR TITLE
Fix runtests on Django 1.7

### DIFF
--- a/{{cookiecutter.repo_name}}/runtests.py
+++ b/{{cookiecutter.repo_name}}/runtests.py
@@ -24,9 +24,11 @@ try:
 
     try:
         import django
-        django.setup()
+        setup = django.setup
     except AttributeError:
         pass
+    else:
+        setup()
 
     from django_nose import NoseTestSuiteRunner
 except ImportError:


### PR DESCRIPTION
Django 1.7 [requires `django.setup()`](https://docs.djangoproject.com/en/dev/releases/1.7/#standalone-scripts) when using Django in standalone scripts. This function does not exist in previous versions of Django, hence the try-except block.
