### PR TITLE
Use Django's Testcase

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,12 +1,12 @@
 {
-  "full_name": "Paul Hallett",
-  "email": "hello@phalt.co",
-  "github_username": "phalt",
-  "project_name": "dj-webhook",
-  "repo_name": "djwebhook",
-  "app_name": "djwebhook",
-  "project_short_description": "Amazingly simple webhook integration for your django projects.",
-  "release_date": "2014-02-01",
+  "full_name": "Your full name here",
+  "email": "you@example.com",
+  "github_username": "yourname",
+  "project_name": "dj-package",
+  "repo_name": "dj-package",
+  "app_name": "djpackage",
+  "project_short_description": "Your project description goes here",
+  "release_date": "2014-01-01",
   "year": "2014",
   "version": "0.1.0"
 }

--- a/{{cookiecutter.repo_name}}/requirements-test.txt
+++ b/{{cookiecutter.repo_name}}/requirements-test.txt
@@ -4,5 +4,7 @@ coveralls
 mock>=1.0.1
 nose>=1.3.0
 django-nose>=1.2
+flake8>=2.1.0
+tox>=1.7.0
 
 # Additional test requirements go here

--- a/{{cookiecutter.repo_name}}/tests/test_models.py
+++ b/{{cookiecutter.repo_name}}/tests/test_models.py
@@ -10,12 +10,12 @@ Tests for `{{ cookiecutter.repo_name }}` models module.
 
 import os
 import shutil
-import unittest
+from django.test import TestCase
 
 from {{ cookiecutter.app_name }} import models
 
 
-class Test{{ cookiecutter.app_name|capitalize }}(unittest.TestCase):
+class Test{{ cookiecutter.app_name|capitalize }}(TestCase):
 
     def setUp(self):
         pass


### PR DESCRIPTION
This update replaces unittest.TestCase with Django’s own TestCase.

This is likely to be favoured by most users of this package, so I thought having the default set to Django’s TestCase would be preferable. The means Django specific test features (such as the loading of fixture files) will work as intended for the Django app.

I am aware that this might not be preferred, so I'll leave it up to your judgement to merge or to decline.

I have also added Flake8 and tox to the requirements-test.txt file, as I noticed they were missing, but required by some parts of the Makefile.