### PR TITLE
runtests.py: Print ImportError stack trace

### DIFF
--- a/{{cookiecutter.repo_name}}/runtests.py
+++ b/{{cookiecutter.repo_name}}/runtests.py
@@ -32,6 +32,8 @@ try:
 
     from django_nose import NoseTestSuiteRunner
 except ImportError:
+    import traceback
+    traceback.print_exc()
     raise ImportError("To fix this error, run: pip install -r requirements-test.txt")
 
 


### PR DESCRIPTION
Makes it easier to figure out what's missing from `requirements.txt` or `requirements-test.txt`.
