### PR TITLE
Add MIDDLEWARE_CLASSES to runtests.py

### DIFF
--- a/{{cookiecutter.repo_name}}/runtests.py
+++ b/{{cookiecutter.repo_name}}/runtests.py
@@ -20,6 +20,7 @@ try:
         ],
         SITE_ID=1,
         NOSE_ARGS=['-s'],
+        MIDDLEWARE_CLASSES=(),
     )
 
     try:


### PR DESCRIPTION
Django 1.7 throws a warning:

```
?: (1_7.W001) MIDDLEWARE_CLASSES is not set.
HINT: Django 1.7 changed the global defaults for the MIDDLEWARE_CLASSES. django.contrib.sessions.middleware.SessionMiddleware, django.contrib.auth.middleware.AuthenticationMiddleware, and django.contrib.messages.middleware.MessageMiddleware were removed from the defaults. If your project needs these middleware then you should configure this setting.
```

Setting it empty on runtests.py by default might be helpful :)