### PR TITLE
Correct help for Makefile to match the test-all target

### DIFF
--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -5,7 +5,7 @@ help:
 	@echo "clean-pyc - remove Python file artifacts"
 	@echo "lint - check style with flake8"
 	@echo "test - run tests quickly with the default Python"
-	@echo "testall - run tests on every Python version with tox"
+	@echo "test-all - run tests on every Python version with tox"
 	@echo "coverage - check code coverage quickly with the default Python"
 	@echo "docs - generate Sphinx HTML documentation, including API docs"
 	@echo "release - package and upload a release"


### PR DESCRIPTION
I noticed when I used this project that the help didn't match the actual targets, it was just a matter of adding a dash. Hooray! :smile: 