### PR TITLE
Fix documentation generation

### DIFF
--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -41,7 +41,7 @@ coverage:
 docs:
 	rm -f docs/{{ cookiecutter.repo_name }}.rst
 	rm -f docs/modules.rst
-	sphinx-apidoc -o docs/ {{ cookiecutter.repo_name }}
+	sphinx-apidoc -o docs/ {{ cookiecutter.app_name }}
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 	open docs/_build/html/index.html

--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -27,7 +27,7 @@ Install {{ cookiecutter.project_name }}::
 
 Then use it in a project::
 
-    import {{ cookiecutter.repo_name }}
+    import {{ cookiecutter.app_name }}
 
 Features
 --------

--- a/{{cookiecutter.repo_name}}/docs/usage.rst
+++ b/{{cookiecutter.repo_name}}/docs/usage.rst
@@ -4,4 +4,4 @@ Usage
 
 To use {{ cookiecutter.project_name }} in a project::
 
-    import {{ cookiecutter.repo_name }}
+    import {{ cookiecutter.app_name }}


### PR DESCRIPTION
The "make docs" command gives an error when your app_name is not the same as the repo_name.
Also fixes the usage.rst to contain the correct default import (the app_name instead of the repo_name)

This should fix it.