### PR TITLE
Validate app name in hook

### DIFF
--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,9 +1,15 @@
 import re
 import sys
 
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
+logger = logging.getLogger('pre_gen_project')
+
 APP_REGEX = r'^[_a-zA-Z][_a-zA-Z0-9]+$'
 
 app_name = '{{cookiecutter.app_name}}'
 
 if not re.match(APP_REGEX, app_name):
+    logger.error('Invalid value for app_name "{}"'.format(app_name))
     sys.exit(1)

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,0 +1,9 @@
+import re
+import sys
+
+APP_REGEX = r'^[_a-zA-Z][_a-zA-Z0-9]+$'
+
+app_name = '{{cookiecutter.app_name}}'
+
+if not re.match(APP_REGEX, app_name):
+    sys.exit(1)


### PR DESCRIPTION
Add a **pre_gen_project** hook to validate ``app_name`` to address the warning in [how-to-create-installable-django-packages](http://www.pydanny.com/how-to-create-installable-django-packages.html) :grin: 

See [cookiecutter docs](https://cookiecutter.readthedocs.org/en/latest/advanced_usage.html#example-validating-template-variables)