### PR TITLE
Updated setup.py

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -33,7 +33,7 @@ readme = open('README.rst').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
 setup(
-    name='{{ cookiecutter.project_name }}',
+    name='{{ cookiecutter.repo_name }}',
     version=version,
     description="""{{ cookiecutter.project_short_description }}""",
     long_description=readme + '\n\n' + history,


### PR DESCRIPTION
The `cookiecutter` would be printing out the documentations to use the repo_name, the pypi should also be registered in the same name.

In README.rst
>        pip install {{ cookiecutter.repo_name }}