### PR TITLE
Updated README.rst

### DIFF
--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -51,4 +51,4 @@ Tools used in rendering this package:
 *  `cookiecutter-pypackage`_
 
 .. _Cookiecutter: https://github.com/audreyr/cookiecutter
-.. _`cookiecutter-pypackage`: https://github.com/pydanny/cookiecutter-djangopackage
+.. _`cookiecutter-djangopackage`: https://github.com/pydanny/cookiecutter-djangopackage


### PR DESCRIPTION
The package name is `cookiecutter-djangopackage` instead of `cookiecutter-pypackage`. 
