### PR TITLE
Fixes variable name in setup.py

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -11,7 +11,7 @@ except ImportError:
 
 
 def get_version(*file_paths):
-    filename = os.path.join(os.path.dirname(__file__), *parts)
+    filename = os.path.join(os.path.dirname(__file__), *file_paths)
     version_file = open(filename).read()
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
                               version_file, re.M)


### PR DESCRIPTION
The variable in setup.py is supposed to be named *file_paths but it is named *parts instead. This patch fixes that.