### PR TITLE
CONTRIBUTING: fix indents following code blocks

### DIFF
--- a/{{cookiecutter.repo_name}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.repo_name}}/CONTRIBUTING.rst
@@ -72,16 +72,16 @@ Ready to contribute? Here's how to set up `{{ cookiecutter.repo_name }}` for loc
 
     $ git checkout -b name-of-your-bugfix-or-feature
 
-Now you can make your changes locally.
+   Now you can make your changes locally.
 
 5. When you're done making changes, check that your changes pass flake8 and the
-tests, including testing other Python versions with tox::
+   tests, including testing other Python versions with tox::
 
-    $ flake8 {{ cookiecutter.app_name }} tests
-    $ python setup.py test
-    $ tox
+        $ flake8 {{ cookiecutter.app_name }} tests
+        $ python setup.py test
+        $ tox
 
-To get flake8 and tox, just pip install them into your virtualenv. 
+   To get flake8 and tox, just pip install them into your virtualenv. 
 
 6. Commit your changes and push your branch to GitHub::
 


### PR DESCRIPTION
Two steps in the numbered list had text, a code block and more text. That text was rendered at the body level rather than as part of the list. This commit adjusts the indentation so the code blocks are indented and the trailing text continues at the level of the the list item text.