### PR TITLE
Make MakeFile self documenting

### DIFF
--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -1,44 +1,37 @@
-.PHONY: clean-pyc clean-build docs
+.PHONY: clean-pyc clean-build docs help
+.DEFAULT_GOAL := help
 
 help:
-	@echo "clean-build - remove build artifacts"
-	@echo "clean-pyc - remove Python file artifacts"
-	@echo "lint - check style with flake8"
-	@echo "test - run tests quickly with the default Python"
-	@echo "test-all - run tests on every Python version with tox"
-	@echo "coverage - check code coverage quickly with the default Python"
-	@echo "docs - generate Sphinx HTML documentation, including API docs"
-	@echo "release - package and upload a release"
-	@echo "sdist - package"
+	@perl -nle'print $& if m{^[a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'
 
 clean: clean-build clean-pyc
 
-clean-build:
+clean-build: ## remove build artifacts
 	rm -fr build/
 	rm -fr dist/
 	rm -fr *.egg-info
 
-clean-pyc:
+clean-pyc: ## remove Python file artifacts
 	find . -name '*.pyc' -exec rm -f {} +
 	find . -name '*.pyo' -exec rm -f {} +
 	find . -name '*~' -exec rm -f {} +
 
-lint:
+lint: ## check style with flake8
 	flake8 {{ cookiecutter.app_name }} tests
 
-test:
+test: ## run tests quickly with the default Python
 	python runtests.py tests
 
-test-all:
+test-all: ## run tests on every Python version with tox
 	tox
 
-coverage:
+coverage: ## check code coverage quickly with the default Python
 	coverage run --source {{ cookiecutter.app_name }} runtests.py tests
 	coverage report -m
 	coverage html
 	open htmlcov/index.html
 
-docs:
+docs: ## generate Sphinx HTML documentation, including API docs
 	rm -f docs/{{ cookiecutter.repo_name }}.rst
 	rm -f docs/modules.rst
 	sphinx-apidoc -o docs/ {{ cookiecutter.app_name }}
@@ -46,10 +39,10 @@ docs:
 	$(MAKE) -C docs html
 	open docs/_build/html/index.html
 
-release: clean
+release: clean ## package and upload a release
 	python setup.py sdist upload
 	python setup.py bdist_wheel upload
 
-sdist: clean
+sdist: clean ## package
 	python setup.py sdist
 	ls -l dist


### PR DESCRIPTION
As [per this blog post](http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html) it will now pull out the inline comments, then sort and colour code them for display whenever anyone runs `make`.

## Pros
- Documentation is inline with the commands so need to scroll up and down
- Output is sorted and nicely ANSI coloured
- New comments are added automatically to the `help` output

## Cons
- Documentation does not appear in a single unified place in source file, only when running `make`