### PR TITLE
Fix issue with automatic year detection

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,7 +6,7 @@
   "repo_name": "dj-package",
   "app_name": "djpackage",
   "project_short_description": "Your project description goes here",
-  "models": "Comma-seperated list of models",
+  "models": "Comma-separated list of models",
   "release_date": "{% now 'local' %}",
   "year": "{{ cookiecutter.now[:4] }}",
   "version": "0.1.0"

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,6 +8,6 @@
   "project_short_description": "Your project description goes here",
   "models": "Comma-separated list of models",
   "release_date": "{% now 'local' %}",
-  "year": "{{ cookiecutter.now[:4] }}",
+  "year": "{% now 'local', '%Y' %}",
   "version": "0.1.0"
 }


### PR DESCRIPTION
I ran into an error with the default year detection:
```
Unable to render variable 'year'
Error message: 'dict object' has no attribute 'now'
```
I'm not exactly sure where cookiecutter.now is injected, so I went ahead and extracted the year from the local time (same method as how the default date is calculated.) I also updated the README to reflect the recent changes.