### PR TITLE
Allow ability to specify Django versions to run tests against in tox

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -7,6 +7,7 @@
   "app_name": "djpackage",
   "project_short_description": "Your project description goes here",
   "models": "Comma-separated list of models",
+  "django_versions": "1.8,1.9",
   "release_date": "{% now 'local' %}",
   "year": "{% now 'local', '%Y' %}",
   "version": "0.1.0"

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -13,3 +13,10 @@ app_name = '{{cookiecutter.app_name}}'
 if not re.match(APP_REGEX, app_name):
     logger.error('Invalid value for app_name "{}"'.format(app_name))
     sys.exit(1)
+
+ALLOWED_VERSIONS = ["1.7", "1.8", "1.9", "1.10", "master"]
+
+for django_version in '{{cookiecutter.django_versions}}'.split(","):
+	if str(django_version).strip() not in ALLOWED_VERSIONS:
+		logger.error('Invalid Django version "{}". '.format(django_version))
+		sys.exit(1)

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -62,17 +62,19 @@ setup(
     keywords='{{ cookiecutter.repo_name }}',
     classifiers=[
         'Development Status :: 3 - Alpha',
-        'Framework :: Django',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
+        'Framework :: Django',{% if '1.7' in cookiecutter.django_versions %}
+        'Framework :: Django :: 1.7',{% endif %}{% if '1.8' in cookiecutter.django_versions %}
+        'Framework :: Django :: 1.8',{% endif %}{% if '1.9' in cookiecutter.django_versions %}
+        'Framework :: Django :: 1.9',{% endif %}{% if '1.10' in cookiecutter.django_versions %}
+        'Framework :: Django :: 1.10',{% endif %}
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3',{% if '1.7' in cookiecutter.django_versions or '1.8' in cookiecutter.django_versions %}
+        'Programming Language :: Python :: 3.3',{% endif %}
+        'Programming Language :: Python :: 3.4',{% if '1.7' != cookiecutter.django_versions %}
+        'Programming Language :: Python :: 3.5',{% endif %}
     ],
 )

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -1,9 +1,32 @@
 [tox]
-envlist = py27, py33, py34, py35
+envlist ={% if '1.7' in cookiecutter.django_versions %}
+    py27-django17
+    py32-django17
+    py33-django17
+    py34-django17{% endif %}{% if '1.8' in cookiecutter.django_versions %}
+    py27-django18
+    py32-django18
+    py33-django18
+    py34-django18
+    py35-django18{% endif %}{% if '1.9' in cookiecutter.django_versions %}
+    py27-django19
+    py34-django19
+    py35-django19{% endif %}{% if '1.10' in cookiecutter.django_versions %}
+    py27-django110
+    py34-django110
+    py35-django110{% endif %}{% if 'master' in cookiecutter.django_versions %}
+    py27-djangomaster
+    py34-djangomaster
+    py35-djangomaster{% endif %}
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/{{ cookiecutter.app_name }}
 commands = python runtests.py
-deps =
+deps ={% if '1.7' in cookiecutter.django_versions %}
+    django-17: Django>=1.7,<1.8{% endif %}{% if '1.8' in cookiecutter.django_versions %}
+    django-18: Django>=1.8,<1.9{% endif %}{% if '1.9' in cookiecutter.django_versions %}
+    django-19: Django>=1.9,<1.10{% endif %}{% if '1.10' in cookiecutter.django_versions %}
+    django-110: Django>=1.10{% endif %}{% if 'master' in cookiecutter.django_versions %}
+    django-master: https://github.com/django/django/archive/master.tar.gz{% endif %}
     -r{toxinidir}/requirements-test.txt


### PR DESCRIPTION
related to #49 

There are remaining references to Django & Python versions in CONTRIBUTING.md that I am not quite adept enough with the templating system to customize. I am also not sure whether this should change the Travis CI configuration, or requirements.txt & requirements-test.txt.