### PR TITLE
tests for urls and views and correting model.strip() in some places

### DIFF
--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -45,11 +45,59 @@ def test_readme(cookies):
 def test_models(cookies):
     pass
 
-def test_views(cookies):
-    pass
 
-def test_urls(cookies):
-    pass
+def test_views_with_models(cookies):
+    """
+    Test case to assert if the views are created when the models are passed
+    """
+    extra_context = {'models': 'Pug,Dog', 'app_name': 'cookies'}
+    with bake_in_temp_dir(cookies, extra_context=extra_context) as result:
+        views_file = result.project.join('cookies', 'views.py')
+        views_file_txt = views_file.read()
+        views = ['CreateView', 'DeleteView', 'DetailView', 'UpdateView', 'ListView']
+        for view in views:
+            assert 'Pug{}'.format(view) in views_file_txt
+            assert 'Dog{}'.format(view) in views_file_txt
+
+
+def test_views_without_models(cookies):
+    """
+    Test case to assert that the views.py file is empty when there are no models defined
+    """
+    extra_context = {'app_name': 'cookies'}
+    with bake_in_temp_dir(cookies, extra_context=extra_context) as result:
+        views_file = result.project.join('cookies', 'views.py')
+        views_file_txt = views_file.read()
+        assert views_file_txt == ''
+
+
+def test_urls_regex_with_model(cookies):
+    """
+    Test case to assert that the urls.py file is created when models are passed
+    """
+    extra_context = {'models': 'Pug,Dog', 'app_name': 'cookies'}
+    with bake_in_temp_dir(cookies, extra_context=extra_context) as result:
+        urls_file = result.project.join('cookies', 'urls.py')
+        urls_file_txt = urls_file.read()
+        for model in extra_context['models'].split(','):
+            assert '^{}/~create/$'.format(model) in urls_file_txt
+            assert '^{}/(?P<pk>\d+)/~delete/$'.format(model) in urls_file_txt
+            assert '^{}/(?P<pk>\d+)/$'.format(model) in urls_file_txt
+            assert '^{}/(?P<pk>\d+)/~update/$'.format(model) in urls_file_txt
+            assert '^{}/$'.format(model) in urls_file_txt
+
+
+def test_urls_without_model(cookies):
+    """
+    Test case to assert that the urls.py file has the basic template when there are no models defined
+    """
+    extra_context = {'app_name': 'cookies'}
+    with bake_in_temp_dir(cookies, extra_context=extra_context) as result:
+        urls_file = result.project.join('cookies', 'urls.py')
+        urls_file_txt = urls_file.read()
+        basic_url = "url(r'', TemplateView.as_view(template_name=\"base.html\"))"
+        assert basic_url in urls_file_txt
+
 
 def test_templates(cookies):
     pass

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/models.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/models.py
@@ -5,7 +5,7 @@ from django.db import models
 from model_utils.models import TimeStampedModel
 
 {% for model in cookiecutter.models.split(',') %}
-class {{ model }}(TimeStampedModel):
+class {{ model.strip() }}(TimeStampedModel):
     pass
     
 {% endfor %}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/views.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/views.py
@@ -1,5 +1,5 @@
-# -*- coding: utf-8 -*-
 {% if cookiecutter.models != "Comma-separated list of models" -%}
+# -*- coding: utf-8 -*-
 from django.views.generic import (
     CreateView,
     DeleteView,
@@ -22,9 +22,9 @@ from .models import ({% for model in cookiecutter.models.split(',') %}
 
 {% for model in cookiecutter.models.split(',') -%}
 {% for view in views %}
-class {{ model }}{{ view }}({{ view }}):
+class {{ model.strip() }}{{ view }}({{ view }}):
 
-    model = {{ model }}
+    model = {{ model.strip() }}
 
 {% endfor -%}
 {% endfor -%}


### PR DESCRIPTION
On this pr we have:

* test for views with models being defined
* test for views without models being defined
* test for url with models being defined
* test for url without models being defined
* insertion of .strip() to avoid unwanted spaces in the models names