### PR TITLE
Add issue templates to cookiecutter-djangopackage and generated project

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,16 @@
+* Date you used Cookiecutter DjangoPackage:
+* Cookiecutter version used, if known:
+* Python version:
+* Operating System:
+
+### Description
+
+Describe what you were trying to get done.
+Tell us what happened, what went wrong, and what you expected to happen.
+
+### What I Did
+
+```
+Paste the command(s) you ran and the output.
+If there was a crash, please include the traceback here.
+```

--- a/{{cookiecutter.repo_name}}/.github/ISSUE_TEMPLATE.md
+++ b/{{cookiecutter.repo_name}}/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,16 @@
+* {{ cookiecutter.project_name }} version:
+* Django version:
+* Python version:
+* Operating System:
+
+### Description
+
+Describe what you were trying to get done.
+Tell us what happened, what went wrong, and what you expected to happen.
+
+### What I Did
+
+```
+Paste the command(s) you ran and the output.
+If there was a crash, please include the traceback here.
+```


### PR DESCRIPTION
Create a GitHub issue template for cookiecutter-djangopackage and also for the generated project.