### PR TITLE
Update django versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ It prompts you for information that it uses to create the app, with defaults in 
     app_name [blogging_for_humans]:
     project_short_description [Your project description goes here]: A sample Django package
     models [Comma-separated list of models]: Scoop, Flavor
-    django_versions [1.8,1.9]:
+    django_versions [1.8,1.9,1.10]:
     version [0.1.0]:
     create_example_project [N]:
     Select open_source_license:

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -7,7 +7,7 @@
   "app_name": "{{ cookiecutter.repo_name.lower()|replace(' ', '_')|replace('-', '_') }}",
   "project_short_description": "Your project description goes here",
   "models": "Comma-separated list of models",
-  "django_versions": "1.8,1.9",
+  "django_versions": "1.8,1.9,1.10",
   "version": "0.1.0",
   "create_example_project": "N",
   "open_source_license": ["MIT", "BSD", "ISCL", "Apache Software License 2.0", "Not open source"]

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -14,7 +14,7 @@ if not re.match(APP_REGEX, app_name):
     logger.error('Invalid value for app_name "{}"'.format(app_name))
     sys.exit(1)
 
-ALLOWED_VERSIONS = ["1.7", "1.8", "1.9", "1.10", "master"]
+ALLOWED_VERSIONS = ["1.8", "1.9", "1.10", "master"]
 
 for django_version in '{{cookiecutter.django_versions}}'.split(","):
 	if str(django_version).strip() not in ALLOWED_VERSIONS:

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -57,8 +57,7 @@ setup(
     keywords='{{ cookiecutter.repo_name }}',
     classifiers=[
         'Development Status :: 3 - Alpha',
-        'Framework :: Django',{% if '1.7' in cookiecutter.django_versions %}
-        'Framework :: Django :: 1.7',{% endif %}{% if '1.8' in cookiecutter.django_versions %}
+        'Framework :: Django',{% if '1.8' in cookiecutter.django_versions %}
         'Framework :: Django :: 1.8',{% endif %}{% if '1.9' in cookiecutter.django_versions %}
         'Framework :: Django :: 1.9',{% endif %}{% if '1.10' in cookiecutter.django_versions %}
         'Framework :: Django :: 1.10',{% endif %}
@@ -67,10 +66,10 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',{% if '1.7' in cookiecutter.django_versions or '1.8' in cookiecutter.django_versions %}
+        'Programming Language :: Python :: 3',{% if '1.8' in cookiecutter.django_versions %}
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',{% endif %}
-        'Programming Language :: Python :: 3.4',{% if '1.7' != cookiecutter.django_versions %}
-        'Programming Language :: Python :: 3.5',{% endif %}
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
 )

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-envlist ={% if '1.7' in cookiecutter.django_versions %}
-    {py27,py32,py33,py34}-django17{% endif %}{% if '1.8' in cookiecutter.django_versions %}
+envlist ={% if '1.8' in cookiecutter.django_versions %}
     {py27,py32,py33,py34,py35}-django18{% endif %}{% if '1.9' in cookiecutter.django_versions %}
     {py27,py34,py35}-django19{% endif %}{% if '1.10' in cookiecutter.django_versions %}
     {py27,py34,py35}-django110{% endif %}{% if 'master' in cookiecutter.django_versions %}
@@ -10,8 +9,7 @@ envlist ={% if '1.7' in cookiecutter.django_versions %}
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/{{ cookiecutter.app_name }}
 commands = python runtests.py
-deps ={% if '1.7' in cookiecutter.django_versions %}
-    django-17: Django>=1.7,<1.8{% endif %}{% if '1.8' in cookiecutter.django_versions %}
+deps ={% if '1.8' in cookiecutter.django_versions %}
     django-18: Django>=1.8,<1.9{% endif %}{% if '1.9' in cookiecutter.django_versions %}
     django-19: Django>=1.9,<1.10{% endif %}{% if '1.10' in cookiecutter.django_versions %}
     django-110: Django>=1.10{% endif %}{% if 'master' in cookiecutter.django_versions %}


### PR DESCRIPTION
Add support for 1.10 by default and drop support for 1.7 as it's unsupported upstream.