### PR TITLE
Setup to use Tox and fix Tox envlist 

### DIFF
--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -136,7 +136,16 @@ def test_travis(cookies):
 
         travis_file = result.project.join('.travis.yml')
         travis_text = travis_file.read()
-        assert 'script: coverage run --source cookie_lover runtests.py' in travis_text
+        assert 'script: tox -e $TOX_ENV' in travis_text
+
+
+def test_tox(cookies):
+    extra_context = {'app_name': 'cookie_lover'}
+    with bake_in_temp_dir(cookies, extra_context=extra_context) as result:
+
+        tox_file = result.project.join('tox.ini')
+        tox_text = tox_file.read()
+        assert 'commands = coverage run --source cookie_lover runtests.py' in tox_text
 
 
 def test_authors(cookies):
@@ -175,8 +184,18 @@ def test_django_versions_default(cookies):
 
         tox_file = result.project.join('tox.ini')
         tox_text = tox_file.read()
-        assert "{py27,py32,py33,py34,py35}-django18" in tox_text
-        assert "{py27,py34,py35}-django19" in tox_text
+        assert "{py27,py32,py33,py34,py35}-django-18" in tox_text
+        assert "{py27,py34,py35}-django-19" in tox_text
+        travis_file = result.project.join('.travis.yml')
+        travis_text = travis_file.read()
+        assert 'py27-django-18' in travis_text
+        assert 'py32-django-18' in travis_text
+        assert 'py33-django-18' in travis_text
+        assert 'py34-django-18' in travis_text
+        assert 'py35-django-18' in travis_text
+        assert 'py27-django-19' in travis_text
+        assert 'py34-django-19' in travis_text
+        assert 'py35-django-19' in travis_text
         setup_file = result.project.join('setup.py')
         setup_text = setup_file.read()
         assert "'Framework :: Django :: 1.8'," in setup_text
@@ -200,8 +219,14 @@ def test_new_django_versions(cookies):
 
         tox_file = result.project.join('tox.ini')
         tox_text = tox_file.read()
-        assert "{py27,py34,py35}-django110" in tox_text
+        assert "{py27,py34,py35}-django-110" in tox_text
         assert 'django19' not in tox_text
+        travis_file = result.project.join('.travis.yml')
+        travis_text = travis_file.read()
+        assert 'py27-django-110' in travis_text
+        assert 'py34-django-110' in travis_text
+        assert 'py35-django-110' in travis_text
+        assert 'django19' not in travis_text
         setup_file = result.project.join('setup.py')
         setup_text = setup_file.read()
         assert "'Framework :: Django :: 1.10'," in setup_text

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -59,7 +59,7 @@ def test_readme(cookies):
         readme_file = result.project.join('README.rst')
         readme_lines = [x.strip() for x in readme_file.readlines(cr=False)]
         assert 'Then use it in a project::' in readme_lines
-        assert '(myenv) $ pip install -r requirements_test.txt' in readme_lines
+        assert '(myenv) $ pip install tox' in readme_lines
 
 
 def test_models(cookies):

--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -4,18 +4,36 @@ language: python
 
 python:
   - "3.5"
-  - "3.4"
-  - "3.3"
-  - "2.7"
 
-before_install:
-  - pip install codecov
+env: {% if '1.8' in cookiecutter.django_versions %}
+  - TOX_ENV=py35-django-18
+  - TOX_ENV=py34-django-18
+  - TOX_ENV=py33-django-18
+  - TOX_ENV=py32-django-18
+  - TOX_ENV=py27-django-18{% endif %}{% if '1.9' in cookiecutter.django_versions %}
+  - TOX_ENV=py35-django-19
+  - TOX_ENV=py34-django-19
+  - TOX_ENV=py27-django-19{% endif %}{% if '1.10' in cookiecutter.django_versions %}
+  - TOX_ENV=py35-django-110
+  - TOX_ENV=py34-django-110
+  - TOX_ENV=py27-django-110{% endif %}{% if 'master' in cookiecutter.django_versions %}
+  - TOX_ENV=py34-django-master
+  - TOX_ENV=py35-django-master
+  - TOX_ENV=py27-django-master{% endif %}
+
+matrix:
+  fast_finish: true{% if 'master' in cookiecutter.django_versions %}
+  allow_failures:
+    - env: TOX_ENV=py27-django-master
+    - env: TOX_ENV=py34-django-master
+    - env: TOX_ENV=py35-django-master{% endif %}
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -r requirements_test.txt
 
 # command to run tests using coverage, e.g. python setup.py test
-script: coverage run --source {{ cookiecutter.app_name }} runtests.py
+script:
+  - tox -e $TOX_ENV
 
 after_success:
-  - codecov
+  - codecov -e TOX_ENV

--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -32,8 +32,7 @@ matrix:
 install: pip install -r requirements_test.txt
 
 # command to run tests using coverage, e.g. python setup.py test
-script:
-  - tox -e $TOX_ENV
+script: tox -e $TOX_ENV
 
 after_success:
   - codecov -e TOX_ENV

--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -39,8 +39,8 @@ Does the code actually work?
 ::
 
     source <YOURVIRTUALENV>/bin/activate
-    (myenv) $ pip install -r requirements_test.txt
-    (myenv) $ python runtests.py
+    (myenv) $ pip install tox
+    (myenv) $ tox
 
 Credits
 ---------

--- a/{{cookiecutter.repo_name}}/requirements.txt
+++ b/{{cookiecutter.repo_name}}/requirements.txt
@@ -1,3 +1,2 @@
-django>=1.9.6
 {% if cookiecutter.models != "Comma-separated list of models" %}django-model-utils>=2.0{% endif %}
 # Additional requirements go here

--- a/{{cookiecutter.repo_name}}/requirements_dev.txt
+++ b/{{cookiecutter.repo_name}}/requirements_dev.txt
@@ -1,4 +1,3 @@
 bumpversion==0.5.3
 wheel==0.29.0
-django>=1.9.6
 {% if cookiecutter.models != "Comma-separated list of models" %}django-model-utils>=2.0{% endif %}

--- a/{{cookiecutter.repo_name}}/requirements_test.txt
+++ b/{{cookiecutter.repo_name}}/requirements_test.txt
@@ -1,4 +1,3 @@
-django>=1.9.6
 coverage==4.2
 mock>=1.0.1
 flake8>=2.1.0

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -8,8 +8,7 @@ envlist ={% if '1.8' in cookiecutter.django_versions %}
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/{{ cookiecutter.app_name }}
-commands =
-    coverage run --source {{ cookiecutter.app_name }} runtests.py
+commands = coverage run --source {{ cookiecutter.app_name }} runtests.py
 deps ={% if '1.8' in cookiecutter.django_versions %}
     django-18: Django>=1.8,<1.9{% endif %}{% if '1.9' in cookiecutter.django_versions %}
     django-19: Django>=1.9,<1.10{% endif %}{% if '1.10' in cookiecutter.django_versions %}

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -1,17 +1,24 @@
 [tox]
 envlist ={% if '1.8' in cookiecutter.django_versions %}
-    {py27,py32,py33,py34,py35}-django18{% endif %}{% if '1.9' in cookiecutter.django_versions %}
-    {py27,py34,py35}-django19{% endif %}{% if '1.10' in cookiecutter.django_versions %}
-    {py27,py34,py35}-django110{% endif %}{% if 'master' in cookiecutter.django_versions %}
-    {py27,py34,py35}-djangomaster{% endif %}
+    {py27,py32,py33,py34,py35}-django-18{% endif %}{% if '1.9' in cookiecutter.django_versions %}
+    {py27,py34,py35}-django-19{% endif %}{% if '1.10' in cookiecutter.django_versions %}
+    {py27,py34,py35}-django-110{% endif %}{% if 'master' in cookiecutter.django_versions %}
+    {py27,py34,py35}-django-master{% endif %}
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/{{ cookiecutter.app_name }}
-commands = python runtests.py
+commands =
+    coverage run --source {{ cookiecutter.app_name }} runtests.py
 deps ={% if '1.8' in cookiecutter.django_versions %}
     django-18: Django>=1.8,<1.9{% endif %}{% if '1.9' in cookiecutter.django_versions %}
     django-19: Django>=1.9,<1.10{% endif %}{% if '1.10' in cookiecutter.django_versions %}
     django-110: Django>=1.10{% endif %}{% if 'master' in cookiecutter.django_versions %}
     django-master: https://github.com/django/django/archive/master.tar.gz{% endif %}
     -r{toxinidir}/requirements_test.txt
+basepython =
+    py35: python3.5
+    py34: python3.4
+    py33: python3.3
+    py32: python3.2
+    py27: python2.7


### PR DESCRIPTION
Relates to #107. Remove Django from `requirements*.txt`, and let Tox manage installation of the right version. Not sure if should be removed from the main `requirements.txt` though?

Feeding back after tweaking the result of cookie cutter for: https://github.com/browniebroke/django-acme