### PR TITLE
Set a sensible config for flake8 in setup.cfg

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -9,3 +9,13 @@ tag = True
 
 [wheel]
 universal = 1
+
+[flake8]
+ignore = D203
+exclude =
+	.git,
+	.tox
+	docs/source/conf.py,
+	build,
+	dist
+max-line-length = 119


### PR DESCRIPTION
- Set max-line-length same as [from Django](https://github.com/django/django/blob/master/setup.cfg) itself.
- Disable D203 disabled as it [conflicts](https://gitlab.com/pycqa/flake8-docstrings/issues/8) with other recommendations.
- Exclude a few files we don't want processed by flake8