### PR TITLE
Drop python 3.2 support for Django 1.8. Fixes #174 . Django 1.8 suppo…

### DIFF
--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -9,7 +9,6 @@ env: {% if '1.8' in cookiecutter.django_versions %}
   - TOX_ENV=py35-django-18
   - TOX_ENV=py34-django-18
   - TOX_ENV=py33-django-18
-  - TOX_ENV=py32-django-18
   - TOX_ENV=py27-django-18{% endif %}{% if '1.9' in cookiecutter.django_versions %}
   - TOX_ENV=py35-django-19
   - TOX_ENV=py34-django-19

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -80,7 +80,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',{% if '1.8' in cookiecutter.django_versions %}
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',{% endif %}
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist ={% if '1.8' in cookiecutter.django_versions %}
-    {py27,py32,py33,py34,py35}-django-18{% endif %}{% if '1.9' in cookiecutter.django_versions %}
+    {py27,py33,py34,py35}-django-18{% endif %}{% if '1.9' in cookiecutter.django_versions %}
     {py27,py34,py35}-django-19{% endif %}{% if '1.10' in cookiecutter.django_versions %}
     {py27,py34,py35}-django-110{% endif %}{% if 'master' in cookiecutter.django_versions %}
     {py27,py34,py35}-django-master{% endif %}
@@ -19,5 +19,4 @@ basepython =
     py35: python3.5
     py34: python3.4
     py33: python3.3
-    py32: python3.2
     py27: python2.7


### PR DESCRIPTION
…rt for python 3.2 ended Dec 31st, 2016 and pip has dropped support for python 3.2 wheel as well.