### PR TITLE
Fix flake8 config in setup.cfg

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -13,9 +13,10 @@ universal = 1
 [flake8]
 ignore = D203
 exclude =
-	.git,
-	.tox
-	docs/source/conf.py,
-	build,
-	dist
+    {{ cookiecutter.app_name }}/migrations,
+    .git,
+    .tox,
+    docs/conf.py,
+    build,
+    dist
 max-line-length = 119


### PR DESCRIPTION
- Missing comma at the end of line with ’.tox’
- Correct path of docs’ conf.py
- Exclude migrations folder