### PR TITLE
Adding support for Django 1.11 and Python 3.6

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,7 +8,7 @@
   "app_config_name": "{{ cookiecutter.app_name.replace('_', ' ')|title()|replace(' ', '') }}Config",
   "project_short_description": "Your project description goes here",
   "models": "Comma-separated list of models",
-  "django_versions": "1.8,1.9,1.10",
+  "django_versions": "1.8,1.9,1.10,1.11",
   "version": "0.1.0",
   "create_example_project": "N",
   "open_source_license": ["MIT", "BSD", "ISCL", "Apache Software License 2.0", "Not open source"]

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -14,9 +14,9 @@ if not re.match(APP_REGEX, app_name):
     logger.error('Invalid value for app_name "{}"'.format(app_name))
     sys.exit(1)
 
-ALLOWED_VERSIONS = ["1.8", "1.9", "1.10", "master"]
+ALLOWED_VERSIONS = ["1.8", "1.9", "1.10", "1.11", "master"]
 
 for django_version in '{{cookiecutter.django_versions}}'.split(","):
-	if str(django_version).strip() not in ALLOWED_VERSIONS:
-		logger.error('Invalid Django version "{}". '.format(django_version))
-		sys.exit(1)
+    if str(django_version).strip() not in ALLOWED_VERSIONS:
+        logger.error('Invalid Django version "{}". '.format(django_version))
+        sys.exit(1)

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -182,7 +182,7 @@ def test_django_versions_default(cookies):
         tox_file = result.project.join('tox.ini')
         tox_text = tox_file.read()
         assert "{py27,py33,py34,py35}-django-18" in tox_text
-        assert "{py27,py34,py35}-django-19" in tox_text
+        assert "{py27,py34,py35,py36}-django-19" in tox_text
         travis_file = result.project.join('.travis.yml')
         travis_text = travis_file.read()
         assert 'py27-django-18' in travis_text
@@ -214,7 +214,7 @@ def test_new_django_versions(cookies):
 
         tox_file = result.project.join('tox.ini')
         tox_text = tox_file.read()
-        assert "{py27,py34,py35}-django-110" in tox_text
+        assert "{py27,py34,py35,py36}-django-110" in tox_text
         assert 'django19' not in tox_text
         travis_file = result.project.join('.travis.yml')
         travis_text = travis_file.read()

--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -51,8 +51,8 @@ docs: ## generate Sphinx HTML documentation, including API docs
 	$(BROWSER) docs/_build/html/index.html
 
 release: clean ## package and upload a release
-	python setup.py sdist upload
-	python setup.py bdist_wheel upload
+	python setup.py sdist bdist_wheel
+	twine upload dist/*
 
 sdist: clean ## package
 	python setup.py sdist

--- a/{{cookiecutter.repo_name}}/requirements_dev.txt
+++ b/{{cookiecutter.repo_name}}/requirements_dev.txt
@@ -1,3 +1,4 @@
 bumpversion==0.5.3
 wheel==0.30.0
+twine==1.9.1
 {% if cookiecutter.models != "Comma-separated list of models" %}django-model-utils>=2.0{% endif %}

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -28,7 +28,7 @@ def get_version(*file_paths):
     raise RuntimeError('Unable to find version string.')
 
 
-version = '0.1.0'
+version = '{{ cookiecutter.version }}'
 
 
 if sys.argv[-1] == 'publish':

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -74,7 +74,8 @@ setup(
         'Framework :: Django',{% if '1.8' in cookiecutter.django_versions %}
         'Framework :: Django :: 1.8',{% endif %}{% if '1.9' in cookiecutter.django_versions %}
         'Framework :: Django :: 1.9',{% endif %}{% if '1.10' in cookiecutter.django_versions %}
-        'Framework :: Django :: 1.10',{% endif %}
+        'Framework :: Django :: 1.10',{% endif %}{% if '1.11' in cookiecutter.django_versions %}
+        'Framework :: Django :: 1.11',{% endif %}
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
@@ -84,5 +85,6 @@ setup(
         'Programming Language :: Python :: 3.3',{% endif %}
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -28,7 +28,7 @@ def get_version(*file_paths):
     raise RuntimeError('Unable to find version string.')
 
 
-version = get_version("{{ cookiecutter.app_name }}", "__init__.py")
+version = '0.1.0'
 
 
 if sys.argv[-1] == 'publish':

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -1,9 +1,11 @@
 [tox]
 envlist ={% if '1.8' in cookiecutter.django_versions %}
     {py27,py33,py34,py35}-django-18{% endif %}{% if '1.9' in cookiecutter.django_versions %}
-    {py27,py34,py35}-django-19{% endif %}{% if '1.10' in cookiecutter.django_versions %}
-    {py27,py34,py35}-django-110{% endif %}{% if 'master' in cookiecutter.django_versions %}
+    {py27,py34,py35,py36}-django-19{% endif %}{% if '1.10' in cookiecutter.django_versions %}
+    {py27,py34,py35,py36}-django-110{% endif %}{% if '1.11' in cookiecutter.django_versions %}
+    {py27,py34,py35,py36}-django-111{% endif %}{% if 'master' in cookiecutter.django_versions %}
     {py27,py34,py35}-django-master{% endif %}
+
 
 [testenv]
 setenv =
@@ -12,10 +14,12 @@ commands = coverage run --source {{ cookiecutter.app_name }} runtests.py
 deps ={% if '1.8' in cookiecutter.django_versions %}
     django-18: Django>=1.8,<1.9{% endif %}{% if '1.9' in cookiecutter.django_versions %}
     django-19: Django>=1.9,<1.10{% endif %}{% if '1.10' in cookiecutter.django_versions %}
-    django-110: Django>=1.10{% endif %}{% if 'master' in cookiecutter.django_versions %}
+    django-110: Django>=1.10,<1.11{% endif %}{% if '1.11' in cookiecutter.django_versions %}
+    django-111: Django>=1.11{% endif %}{% if 'master' in cookiecutter.django_versions %}
     django-master: https://github.com/django/django/archive/master.tar.gz{% endif %}
     -r{toxinidir}/requirements_test.txt
 basepython =
+    py36: python3.6
     py35: python3.5
     py34: python3.4
     py33: python3.3


### PR DESCRIPTION
Hi all!

This does the following things:

1. Adds support for python 3.6 in tox and django 1.11;
1. Adds support for using twine. This changes the requirements for dev and a few changes on the makefile
1. Changes the `setup.py` version number to be fixed rather then the result of a function. This happens because `bumpversion` does not work with the current configuration. Fixing it allows `bumpversion` to work perfectly.
1. Converted `pre_gen_project.py` from tabs to spaces

This closes #252 and closes #193 