### PR TITLE
Small typo in the README file.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Now, get Cookiecutter_. Trust me, it's awesome::
 
 Now run it against this repo::
 
-    $ cookiecutter gh:pydanny/cookiecutter-djangopackage.git
+    $ cookiecutter gh:pydanny/cookiecutter-djangopackage
 
 You'll be prompted for some questions, answer them, then it will create a directory that is your new package.
 


### PR DESCRIPTION
When running `cookiecutter gh:pydanny/cookiecutter-djangopackage.git` it returned an error saying `The repository https://github.com/pydanny/cookiecutter-djangopackage.git.git could not be found, have you made a typo?`.