### PR TITLE
Build admin.py boilerplate

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/admin.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+{% if cookiecutter.models != "Comma-separated list of models" %}
+from django.contrib import admin
+
+from .models import (
+{% for model in cookiecutter.models.split(',') %}   {{ model.strip() }},
+{% endfor %})
+
+{% for model in cookiecutter.models.split(',') %}
+@admin.register({{ model.strip() }})
+class {{ model.strip() }}Admin(admin.ModelAdmin):
+    pass
+
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
When I create a new django app, I almost invariably want an admin interface for my models. Since I'm not using the cookiecutter for all new Django projects, figured I'd offer a barebones template to start from.