### PR TITLE
Add Django 3.X, Py3.7-8; Drop Dj1.11, Py2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ dist: xenial
 language: python
 
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
   - "pypy"
 
 install:

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ It prompts you for information that it uses to create the app, with defaults in 
     app_name [blogging_for_humans]:
     project_short_description [Your project description goes here]: A sample Django package
     models [Comma-separated list of models]: Scoop, Flavor
-    django_versions [1.11,2.1]:
+    django_versions [2.2,3.0,3.1]:
     version [0.1.0]:
     create_example_project [N]:
     Select open_source_license:

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,7 +8,7 @@
   "app_config_name": "{{ cookiecutter.app_name.replace('_', ' ')|title()|replace(' ', '') }}Config",
   "project_short_description": "Your project description goes here",
   "models": "Comma-separated list of models",
-  "django_versions": "1.11,2.1",
+  "django_versions": "2.2,3.0,3.1",
   "version": "0.1.0",
   "create_example_project": "N",
   "open_source_license": ["MIT", "BSD", "ISCL", "Apache Software License 2.0", "Not open source"]

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -14,7 +14,7 @@ if not re.match(APP_REGEX, app_name):
     logger.error('Invalid value for app_name "{}"'.format(app_name))
     sys.exit(1)
 
-ALLOWED_VERSIONS = ["1.11", "2.1", "master"]
+ALLOWED_VERSIONS = ["2.2", "3.0", "3.1", "master"]
 
 for django_version in '{{cookiecutter.django_versions}}'.split(","):
     if str(django_version).strip() not in ALLOWED_VERSIONS:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,8 +1,7 @@
-pip==9.0.1
 cookiecutter==1.6.0
 pytest-cookies==0.2.0
 pytest==3.2.2
-tox==2.9.1
+tox==3.20.0
 pytest-cov==2.5.1
 watchdog==0.8.3
 sh==1.12.14

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -181,24 +181,25 @@ def test_django_versions_default(cookies):
 
         tox_file = result.project.join('tox.ini')
         tox_text = tox_file.read()
-        assert "{py27,py35,py36}-django-111" in tox_text
-        assert "{py35,py36,py37}-django-21" in tox_text
+        assert "{py35,py36,py37,py38}-django-22" in tox_text
+        assert "{py36,py37,py38}-django-30" in tox_text
+        assert "{py36,py37,py38}-django-31" in tox_text
         travis_file = result.project.join('.travis.yml')
         travis_text = travis_file.read()
-        assert 'py35-django-111' in travis_text
-        assert 'py36-django-111' in travis_text
-        assert 'py35-django-21' in travis_text
-        assert 'py36-django-21' in travis_text
-        assert 'py37-django-21' in travis_text
+        assert 'py35-django-22' in travis_text
+        assert 'py36-django-22' in travis_text
+        assert 'py37-django-22' in travis_text
+        assert 'py38-django-22' in travis_text
         setup_file = result.project.join('setup.py')
         setup_text = setup_file.read()
-        assert "'Framework :: Django :: 1.11'," in setup_text
-        assert "'Framework :: Django :: 2.1'," in setup_text
-        assert "'Programming Language :: Python :: 2'," in setup_text
-        assert "'Programming Language :: Python :: 2.7'," in setup_text
+        assert "'Framework :: Django :: 2.2'," in setup_text
+        assert "'Framework :: Django :: 3.0'," in setup_text
+        assert "'Framework :: Django :: 3.1'," in setup_text
         assert "'Programming Language :: Python :: 3'," in setup_text
         assert "'Programming Language :: Python :: 3.5'," in setup_text
         assert "'Programming Language :: Python :: 3.6'," in setup_text
+        assert "'Programming Language :: Python :: 3.7'," in setup_text
+        assert "'Programming Language :: Python :: 3.8'," in setup_text
 
 
 def test_new_django_versions(cookies):
@@ -206,7 +207,7 @@ def test_new_django_versions(cookies):
     Test case to assert that the tox.ini & setup.py files are generated with correct versions with a new Django version
     """
 
-    extra_context = {'django_versions': '1.11,2.1'}
+    extra_context = {'django_versions': '2.2,3.0,3.1'}
     with bake_in_temp_dir(cookies, extra_context=extra_context) as result:
 
         tox_file = result.project.join('tox.ini')
@@ -215,20 +216,23 @@ def test_new_django_versions(cookies):
         assert 'django19' not in tox_text
         travis_file = result.project.join('.travis.yml')
         travis_text = travis_file.read()
-        assert 'py27-django-111' in travis_text
-        assert 'py35-django-111' in travis_text
+        assert 'py35-django-22' in travis_text
+        assert 'py36-django-30' in travis_text
+        assert 'py36-django-31' in travis_text
         assert 'django19' not in travis_text
         setup_file = result.project.join('setup.py')
         setup_text = setup_file.read()
-        assert "'Framework :: Django :: 2.1'," in setup_text
-        assert "'Framework :: Django :: 1.11'," in setup_text
-        assert "'Framework :: Django :: 1.9'," not in setup_text
-        assert "'Programming Language :: Python :: 2'," in setup_text
-        assert "'Programming Language :: Python :: 2.7'," in setup_text
+        assert "'Framework :: Django :: 1.11'," not in setup_text
+        assert "'Framework :: Django :: 2.1'," not in setup_text
+        assert "'Framework :: Django :: 2.2'," in setup_text
+        assert "'Framework :: Django :: 3.0'," in setup_text
+        assert "'Framework :: Django :: 3.1'," in setup_text
         assert "'Programming Language :: Python :: 3'," in setup_text
         assert "'Programming Language :: Python :: 3.5'," in setup_text
         assert "'Programming Language :: Python :: 3.6'," in setup_text
+        assert "'Programming Language :: Python :: 2.7'," not in setup_text
         assert "'Programming Language :: Python :: 3.3'," not in setup_text
+        assert "'Programming Language :: Python :: 3.4'," not in setup_text
 
 
 def test_flake8_compliance(cookies):

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -212,7 +212,7 @@ def test_new_django_versions(cookies):
 
         tox_file = result.project.join('tox.ini')
         tox_text = tox_file.read()
-        assert "{py27,py35,py36}-django-111" in tox_text
+        assert "{py27,py35,py36}-django-111" not in tox_text
         assert 'django19' not in tox_text
         travis_file = result.project.join('.travis.yml')
         travis_text = travis_file.read()
@@ -230,6 +230,8 @@ def test_new_django_versions(cookies):
         assert "'Programming Language :: Python :: 3'," in setup_text
         assert "'Programming Language :: Python :: 3.5'," in setup_text
         assert "'Programming Language :: Python :: 3.6'," in setup_text
+        assert "'Programming Language :: Python :: 3.7'," in setup_text
+        assert "'Programming Language :: Python :: 3.8'," in setup_text
         assert "'Programming Language :: Python :: 2.7'," not in setup_text
         assert "'Programming Language :: Python :: 3.3'," not in setup_text
         assert "'Programming Language :: Python :: 3.4'," not in setup_text

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py27, py34, py35, py36, pypy
+envlist = py35, py36, py37, py38, pypy
 skipsdist = true
 
 [testenv]
 whitelist_externals = bash
 deps =
-    Django>=1.11,<=2.2
+    Django>=2.2,<=3.1
     -rrequirements_dev.txt
 
 commands =

--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -5,22 +5,26 @@ language: python
 python:
   - "3.6"
 
-env: {% if '1.11' in cookiecutter.django_versions %}
-  - TOX_ENV=py36-django-111
-  - TOX_ENV=py35-django-111
-  - TOX_ENV=py27-django-111{% endif %}{% if '2.0' in cookiecutter.django_versions %}
-  - TOX_ENV=py36-django-20
-  - TOX_ENV=py35-django-20{% endif %}{% if '2.1' in cookiecutter.django_versions %}
-  - TOX_ENV=py37-django-21
-  - TOX_ENV=py36-django-21
-  - TOX_ENV=py35-django-21{% endif %}{% if 'master' in cookiecutter.django_versions %}
-  - TOX_ENV=py35-django-master
-  - TOX_ENV=py36-django-master{% endif %}
+env: {% if '2.2' in cookiecutter.django_versions %}
+  - TOX_ENV=py38-django-22
+  - TOX_ENV=py37-django-22
+  - TOX_ENV=py36-django-22
+  - TOX_ENV=py35-django-22{% endif %}{% if '3.0' in cookiecutter.django_versions %}
+  - TOX_ENV=py36-django-30
+  - TOX_ENV=py37-django-30
+  - TOX_ENV=py38-django-30{% endif %}{% if '3.1' in cookiecutter.django_versions %}
+  - TOX_ENV=py38-django-31
+  - TOX_ENV=py37-django-31
+  - TOX_ENV=py36-django-31{% endif %}{% if 'master' in cookiecutter.django_versions %}
+  - TOX_ENV=py36-django-master
+  - TOX_ENV=py37-django-master
+  - TOX_ENV=py38-django-master{% endif %}
 
 matrix:
   fast_finish: true{% if 'master' in cookiecutter.django_versions %}
   allow_failures:
-    - env: TOX_ENV=py35-django-master
+    - env: TOX_ENV=py36-django-master
+    - env: TOX_ENV=py37-django-master
     - env: TOX_ENV=py36-django-master{% endif %}
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -71,9 +71,10 @@ setup(
     zip_safe=False,
     keywords='{{ cookiecutter.repo_name }}',
     classifiers=[
-        'Development Status :: 3 - Alpha',{% if '1.11' in cookiecutter.django_versions %}
-        'Framework :: Django :: 1.11',{% endif %}{% if '2.1' in cookiecutter.django_versions %}
-        'Framework :: Django :: 2.1',{% endif %}
+        'Development Status :: 3 - Alpha',{% if '2.2' in cookiecutter.django_versions %}
+        'Framework :: Django :: 2.2',{% endif %}{% if '3.0' in cookiecutter.django_versions %}
+        'Framework :: Django :: 3.0',{% endif %}{% if '3.1' in cookiecutter.django_versions %}
+        'Framework :: Django :: 3.1',{% endif %}
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -78,10 +78,10 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -1,20 +1,22 @@
 [tox]
-envlist ={% if '2.1' in cookiecutter.django_versions %}
-    {py35,py36,py37}-django-21{% endif %}{% if '1.11' in cookiecutter.django_versions %}
-    {py27,py35,py36}-django-111{% endif %}{% if 'master' in cookiecutter.django_versions %}
-    {py35,py36}-django-master{% endif %}
+envlist ={% if '2.2' in cookiecutter.django_versions %}
+    {py35,py36,py37,py38}-django-22{% endif %}{% if '3.0' in cookiecutter.django_versions %}
+    {py36,py37,py38}-django-30{% endif %}{% if '3.1' in cookiecutter.django_versions %}
+    {py36,py37,py38}-django-31{% endif %}{% if 'master' in cookiecutter.django_versions %}
+    {py36,py37,py38}-django-master{% endif %}
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/{{ cookiecutter.app_name }}
 commands = coverage run --source {{ cookiecutter.app_name }} runtests.py
-deps ={% if '1.11' in cookiecutter.django_versions %}
-    django-111: Django>=1.11,<1.12{% endif %}{% if '2.1' in cookiecutter.django_versions %}
-    django-21: Django>=2.1,<2.2{% endif %}{% if 'master' in cookiecutter.django_versions %}
+deps ={% if '2.2' in cookiecutter.django_versions %}
+    django-22: Django>=2.2,<2.3{% endif %}{% if '3.0' in cookiecutter.django_versions %}
+    django-30: Django>=3.0,<3.1{% endif %}{% if '3.1' in cookiecutter.django_versions %}
+    django-31: Django>=3.1,<3.2{% endif %}{% if 'master' in cookiecutter.django_versions %}
     django-master: https://github.com/django/django/archive/master.tar.gz{% endif %}
     -r{toxinidir}/requirements_test.txt
 basepython =
+    py38: python3.8
     py37: python3.7
     py36: python3.6
     py35: python3.5
-    py27: python2.7


### PR DESCRIPTION
Python 2.7 is coming to the end of its lifetime, and many packages like Django are following along. In this PR, I've also added Django 3.0 and Django 3.1 with Python 3.7 and Python 3.8. 